### PR TITLE
re-arrange lists in content

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python/) and [awes
 
 ### See what others have been building with MPS
 
-- [Build with MPS](#build-with-mps) are open source projects that all build on MPS
+- [Built with MPS](#built-with-mps) are open source projects that all built on MPS
 - [Research](#research) contains a list academic papers that make heavy use of MPS
 
 ### Get started with MPS
@@ -22,16 +22,11 @@ To get stated we suggest to look at the tutorials in the following order:
 - [MPS for the Impatient](https://stepik.org/course/71593/) is a free hands-on course that covers the basics of JetBrains MPS from the language designer's perspective, skipping the theoretical topics as well as the practical productivity how-tos.
 - [HeayMeta.tv](https://heavymeta.tv) - A complete MPS tutorial to build your first language by @coolya with lots background information on language design.
 - [MPS Intro Course by @markusvoelter](https://github.com/markusvoelter/mpsintrocourse) is an advanced introduction to MPS in the form of multiple videos as well as a github repository to play around with. It also covers extensions to MPS such as additional notations or the interpreter framework.
-- [Grammar Cells](http://mbeddr.com/files/gc-sle.pdf) An extension to the editor language of MPS. It will help you to create consistent and well-behaving textual notations in MPS with no effort.
 - If you are specificity looking for input on how to build generators [this guide](https://coolya.github.io/maintainable-generators/) contains a set of best practices.
 - The [DSL Engineering Book](http://dslbook.org/) contains detailed discussions of the concepts behind MPS in its Part III on language implementation.
 - For more details on specific MPS topics we refer to [2 books on MPS](http://campagnelab.org/publications/our-books/) as well as the official [MPS User Guide](https://confluence.jetbrains.com/display/MPSD20173/MPS+User%27s+Guide)
 
 [Learning](#learning-mps) contains a list of even more tutorials. In addition [Research](#research) contains a list academic papers that make heavy use of MPS.
-
-### Find existing extensions for MPS
-
-- [Awesome MPS](#awesome-mps) contains a collection of extensions to MPS
 
 ### Get in touch with the community
 
@@ -39,31 +34,46 @@ To get stated we suggest to look at the tutorials in the following order:
 
 ## [Awesome MPS](#awesome-MPS)
 
-- [ANTLR_MPS](https://github.com/CampagneLaboratory/ANTLR_MPS) - An ANTLR language for MPS, and the ToMPS language to help create MPS languages and ANTRL visitors from an ANTLR 4 grammar.
+### Plugins
+
+Plugins that improve MPS.
+
+- [Grammar Cells](http://mbeddr.com/files/gc-sle.pdf) An extension to the editor language of MPS. It will help you to create consistent and well-behaving textual notations in MPS with no effort.
 - [mps-code-reviewer](https://github.com/Workday/mps-code-reviewer) - Code Review for JetBrains MPS providing integration with Bitbucket
 - [digitalember.extensions](https://github.com/digital-ember/digitalember.extensions) - MPS baseLanguage editor extensions for better readability.
 - [Durchblick](https://github.com/coolya/Durchblick) - Simplified editors to increase readability of generators.
-- [ecmascript4mps](https://github.com/mar9000/ecmascript4mps) - ECMAScript language implementation for JetBrains MPS
 - [Editor2PDF](https://github.com/CampagneLaboratory/Editor2PDF) - Serialises editor into PDF files
 - [MPS Extensions](https://github.com/JetBrains/MPS-extensions) - Various extensions to simplify language development.
 - [MPS gradle plugin](https://github.com/mbeddr/mps-gradle-plugin) - A Gradle plugin to build & test langauges and to support various tasks related to custom RCP packaging.
 - [ingrid](https://github.com/premun/ingrid) - Ingrid is a plugin for JetBrains MPS allowing import of ANTLRv4 grammars and create an MPS language out of it.
-- [MPS JSON Language](https://github.com/nkoester/mps-json) - A JSON implementation for MPS.
-- [PlantUML](https://github.com/vjramirez/PlantUML) - Language for PlantUML models, also useful to generate PlantUML diagrams from custom DSL.
 - [Text Generator Plugin](https://github.com/DSLFoundry/mps-plaintextgen) - Alternative Textgen for JetBrains MPS using the standard model to model generation mechanisms.
 - [Nyan Progress Bar](https://plugins.jetbrains.com/plugin/8575-nyan-progress-bar) - Pretty progress bars for IJ based IDEs.
 - [MPS-QA](https://github.com/mbeddr/mps-qa) - This repository contains quality assurance tooling for Jetbrains' MPS.
 
-## [Build with MPS](#build-with-mps)
+## [Built with MPS](#built-with-mps)
+
+### IDEs
+
+Complete IDEs built with MPS.
 
 - [Dutch Tax Office](https://resources.jetbrains.com/storage/products/mps/docs/MPS_DTO_Case_Study.pdf) - Domain-specific languages to implement Dutch tax legislation and process changes of that legislation.
-- [FormatsDSL](https://github.com/ftomassetti/FormatsDSL) - A DSL to describe formats and generate loaders
 - [Hardella IDE](https://hardella.com/en/) - Smart programming environment for PLC
-- [iets3](https://github.com/iets3/iets3.opensource) - Base language for system modelling and specification including basics abstractions for  components, expression, variability, etc
 - [mbeddr](https://github.com/mbeddr/mbeddr.core) - An extensible C implementation in MPS to support embedded software development.
 - [MetaR](https://metar-languages.github.io/) - A IDE for R for people with limited computer science background.
 - [PeoPL](https://github.com/benbehringer/peopl) - A full IDE build upon MPS to manage Software Product Lines.
 - [FASTEN](https://sites.google.com/site/fastenroot) - An IDE for system level formal specification. A stack of DSLs built on top of SMV, verified using the NuSMV model checker.
+
+### Languages
+
+Individual languages.
+
+- [ANTLR_MPS](https://github.com/CampagneLaboratory/ANTLR_MPS) - An ANTLR language for MPS, and the ToMPS language to help create MPS languages and ANTRL visitors from an ANTLR 4 grammar.
+- [ecmascript4mps](https://github.com/mar9000/ecmascript4mps) - ECMAScript language implementation for JetBrains MPS.
+- [MPS JSON Language](https://github.com/nkoester/mps-json) - A JSON implementation for MPS.
+- [PlantUML](https://github.com/vjramirez/PlantUML) - Language for PlantUML models, also useful to generate PlantUML diagrams from custom DSL.
+- [FormatsDSL](https://github.com/ftomassetti/FormatsDSL) - A DSL to describe formats and generate loaders.
+- [iets3](https://github.com/iets3/iets3.opensource) - Base language for system modelling and specification including basics abstractions for  components, expression, variability, etc.
+- [Web languages](https://github.com/dslmeinte/mps-open-source/tree/master/mps-open-source) - a collection of Web-centric, partial language implementations: JSON, JSON Schema, WSDL, XSD, SVG, CSS.
 
 ## [Learning MPS](#learning-mps)
 


### PR DESCRIPTION
(As per discussion in email.)

- I removed the "Find existing extensions for MPS" sub sub section as the contents of the referred section seem to be pretty self-explanatory to me.
- I moved the reference to grammar cells from the "Get started with MPS" to the "Awesome MPS" section.
- I added some of my own stuff.
- A divided the "Built with MPS" section into sub sections "Languages" and IDEs.